### PR TITLE
fix: window.webContents.send to be catchable

### DIFF
--- a/packages/interprocess/src/factories/createMainHandlers.ts
+++ b/packages/interprocess/src/factories/createMainHandlers.ts
@@ -20,23 +20,29 @@ export function createMainHandlers<T extends IPCFactoryProps<T>>(props: T) {
   type Main = IPCMain<typeof props['main']>
   type MainKeys = ProcessKeys<Main>
 
-  const handlers = Object.keys(props.main!).reduce((acc, current) => {
-    const key = current as MainKeys
+  const handlers = Object.keys(props.main!).reduce((acc, currentChannel) => {
+    const ipcChannel = currentChannel as MainKeys
 
     return {
       ...acc,
 
-      [key]: async (listener?: MainHandler<typeof key, Main[typeof key]>) => {
-        const ProvidedHandler = props['main']![key]
+      [ipcChannel]: async (
+        listener?: MainHandler<typeof ipcChannel, Main[typeof ipcChannel]>
+      ) => {
+        const ProvidedHandler = props['main']![ipcChannel]
 
         if (!listener && ProvidedHandler) {
-          return ipcMain.handle(key as string, ProvidedHandler)
+          return ipcMain.handle(ipcChannel, ProvidedHandler)
         }
 
-        return ipcMain.handle(key as string, (_, ...args) => {
+        return ipcMain.handle(ipcChannel, (_, ...args) => {
           const handler = listener as any
 
-          return handler(_, { [key]: ProvidedHandler, data: args[0] }, ...args)
+          return handler(
+            _,
+            { [ipcChannel]: ProvidedHandler, data: args[0] },
+            ...args
+          )
         })
       },
     }

--- a/packages/interprocess/src/factories/createRendererInvokers.ts
+++ b/packages/interprocess/src/factories/createRendererInvokers.ts
@@ -6,12 +6,14 @@ export function createRendererInvokers<T extends IPCFactoryProps<T>>(props: T) {
   type Main = IPCMain<typeof props['main']>
   type MainKeys = ProcessKeys<Main>
 
-  const invokers = Object.keys(props.main!).reduce((acc, current) => {
+  const invokers = Object.keys(props.main!).reduce((acc, currentChannel) => {
+    const ipcChannel = currentChannel as MainKeys
+
     return {
       ...acc,
 
-      [current as MainKeys]: async (...args: any[]) => {
-        return ipcRenderer.invoke(current as string, ...args)
+      [ipcChannel]: async (...args: any[]) => {
+        return ipcRenderer.invoke(ipcChannel, ...args)
       },
     }
   }, {}) as {

--- a/packages/interprocess/src/index.ts
+++ b/packages/interprocess/src/index.ts
@@ -1,2 +1,2 @@
-export { combineIpcs } from './utils'
+export { combineIpcs } from './utils/combineIpcs'
 export * from './factories'

--- a/packages/interprocess/src/ipcs/main.ts
+++ b/packages/interprocess/src/ipcs/main.ts
@@ -1,0 +1,34 @@
+import { ipcMain } from 'electron'
+
+import type { SyncAvailableIpcsOperation } from '../types'
+
+import { isMainProcess } from '../utils/is'
+import { IPC } from '../utils/ipcs'
+import { store } from '../store'
+
+let isAlreadyAvailableRendererIpcsSyncHandlerRegistered = false
+
+interface SyncAvailableIpcsPayload {
+  type: SyncAvailableIpcsOperation
+  key: string
+}
+
+export function registerAvailableRendererIpcsSyncHandler() {
+  if (isAlreadyAvailableRendererIpcsSyncHandlerRegistered || !isMainProcess())
+    return
+
+  ipcMain.handle(
+    IPC.INTERNAL.SYNC_AVAILABLE_RENDERER_IPCS,
+    (_, data: SyncAvailableIpcsPayload) => {
+      if (data.type === 'add') {
+        store.main.availableRendererIpcChannels.add(data.key)
+      }
+
+      if (data.type === 'remove') {
+        store.main.availableRendererIpcChannels.delete(data.key)
+      }
+    }
+  )
+
+  isAlreadyAvailableRendererIpcsSyncHandlerRegistered = true
+}

--- a/packages/interprocess/src/store.ts
+++ b/packages/interprocess/src/store.ts
@@ -1,0 +1,7 @@
+const availableRendererIpcChannels = new Set()
+
+export const store = {
+  main: {
+    availableRendererIpcChannels,
+  },
+}

--- a/packages/interprocess/src/types/index.ts
+++ b/packages/interprocess/src/types/index.ts
@@ -2,6 +2,8 @@ export type IPCMainEvent = Electron.IpcMainInvokeEvent
 export type IPCRendererEvent = Electron.IpcRendererEvent
 export type BrowserWindow = Electron.BrowserWindow
 
+export type SyncAvailableIpcsOperation = 'add' | 'remove'
+
 export type IPCMain<T> = IPC<T, IPCMainEvent>
 export type IPCRenderer<T> = IPC<T, IPCRendererEvent>
 

--- a/packages/interprocess/src/utils/index.ts
+++ b/packages/interprocess/src/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './combineIpcs'

--- a/packages/interprocess/src/utils/ipcs.ts
+++ b/packages/interprocess/src/utils/ipcs.ts
@@ -1,0 +1,5 @@
+export const IPC = {
+  INTERNAL: {
+    SYNC_AVAILABLE_RENDERER_IPCS: '@interprocess:syncAvailableRendererIpcs',
+  },
+}

--- a/packages/interprocess/src/utils/is.ts
+++ b/packages/interprocess/src/utils/is.ts
@@ -1,0 +1,7 @@
+export function isMainProcess() {
+  return process.type === 'browser'
+}
+
+export function isRendererProcess() {
+  return process.type === 'renderer'
+}


### PR DESCRIPTION
# Problem

`window.webContents.send` is asynchronous, but any errors that occurs are not catchable by the main process if you use try/catch or invoke method by interprocess, so when a renderer handler is removed, the main invoking will not catch the expected `"No handler registered for ipcChannelName"`.

# Solution

The solution was to implement a way to synchronize the available handlers on renderer process and remove them from the list when they are removed from there So, when invoking a renderer process handler from main process, it is checked if this handler still exists to be invoked, if it doesn't exist, the expected error is thrown!

Closes #17 