### PR TITLE
fix: where main or renderer handlers declaration are omitted and thrown undefined

### DIFF
--- a/packages/interprocess/src/factories/createMainHandlers.ts
+++ b/packages/interprocess/src/factories/createMainHandlers.ts
@@ -20,33 +20,36 @@ export function createMainHandlers<T extends IPCFactoryProps<T>>(props: T) {
   type Main = IPCMain<typeof props['main']>
   type MainKeys = ProcessKeys<Main>
 
-  const handlers = Object.keys(props.main!).reduce((acc, currentChannel) => {
-    const ipcChannel = currentChannel as MainKeys
+  const handlers = Object.keys(props?.main! || {}).reduce(
+    (acc, currentChannel) => {
+      const ipcChannel = currentChannel as MainKeys
 
-    return {
-      ...acc,
+      return {
+        ...acc,
 
-      [ipcChannel]: async (
-        listener?: MainHandler<typeof ipcChannel, Main[typeof ipcChannel]>
-      ) => {
-        const ProvidedHandler = props['main']![ipcChannel]
+        [ipcChannel]: async (
+          listener?: MainHandler<typeof ipcChannel, Main[typeof ipcChannel]>
+        ) => {
+          const ProvidedHandler = props['main']![ipcChannel]
 
-        if (!listener && ProvidedHandler) {
-          return ipcMain.handle(ipcChannel, ProvidedHandler)
-        }
+          if (!listener && ProvidedHandler) {
+            return ipcMain.handle(ipcChannel, ProvidedHandler)
+          }
 
-        return ipcMain.handle(ipcChannel, (_, ...args) => {
-          const handler = listener as any
+          return ipcMain.handle(ipcChannel, (_, ...args) => {
+            const handler = listener as any
 
-          return handler(
-            _,
-            { [ipcChannel]: ProvidedHandler, data: args[0] },
-            ...args
-          )
-        })
-      },
-    }
-  }, {} as MainHandle<MainKeys, Main>)
+            return handler(
+              _,
+              { [ipcChannel]: ProvidedHandler, data: args[0] },
+              ...args
+            )
+          })
+        },
+      }
+    },
+    {} as MainHandle<MainKeys, Main>
+  )
 
   return handlers
 }

--- a/packages/interprocess/src/factories/createMainInvokers.ts
+++ b/packages/interprocess/src/factories/createMainInvokers.ts
@@ -16,7 +16,7 @@ export function createMainInvokers<T extends IPCFactoryProps<T>>(props: T) {
 
   registerAvailableRendererIpcsSyncHandler()
 
-  const invokers = Object.keys(props.renderer!).reduce(
+  const invokers = Object.keys(props?.renderer! || {}).reduce(
     (acc, currentChannel) => {
       const ipcChannel = currentChannel as RendererKeys
 

--- a/packages/interprocess/src/factories/createRemoveHandlers.ts
+++ b/packages/interprocess/src/factories/createRemoveHandlers.ts
@@ -20,19 +20,22 @@ export function createRemoveHandlers<T extends IPCFactoryProps<T>>(props: T) {
     [Property in R]: () => void
   }
 
-  const mainRemove = Object.keys(props.main!).reduce((acc, currentChannel) => {
-    const ipcChannel = currentChannel as MainKeys
+  const mainRemove = Object.keys(props?.main! || {}).reduce(
+    (acc, currentChannel) => {
+      const ipcChannel = currentChannel as MainKeys
 
-    return {
-      ...acc,
+      return {
+        ...acc,
 
-      [ipcChannel]: () => {
-        ipcMain.removeHandler(ipcChannel)
-      },
-    }
-  }, {}) as RemoveHandlers<MainKeys>
+        [ipcChannel]: () => {
+          ipcMain.removeHandler(ipcChannel)
+        },
+      }
+    },
+    {}
+  ) as RemoveHandlers<MainKeys>
 
-  const rendererRemove = Object.keys(props.renderer!).reduce(
+  const rendererRemove = Object.keys(props?.renderer! || {}).reduce(
     (acc, currentChannel) => {
       const ipcChannel = currentChannel as RendererKeys
 

--- a/packages/interprocess/src/factories/createRendererHandlers.ts
+++ b/packages/interprocess/src/factories/createRendererHandlers.ts
@@ -22,7 +22,7 @@ export function createRendererHandlers<T extends IPCFactoryProps<T>>(props: T) {
   type Renderer = IPCRenderer<typeof props['renderer']>
   type RendererKeys = ProcessKeys<Renderer>
 
-  const handlers = Object.keys(props.renderer!).reduce(
+  const handlers = Object.keys(props?.renderer! || {}).reduce(
     (acc, currentChannel) => {
       const ipcChannel = currentChannel as RendererKeys
 

--- a/packages/interprocess/src/factories/createRendererInvokers.ts
+++ b/packages/interprocess/src/factories/createRendererInvokers.ts
@@ -6,17 +6,20 @@ export function createRendererInvokers<T extends IPCFactoryProps<T>>(props: T) {
   type Main = IPCMain<typeof props['main']>
   type MainKeys = ProcessKeys<Main>
 
-  const invokers = Object.keys(props.main!).reduce((acc, currentChannel) => {
-    const ipcChannel = currentChannel as MainKeys
+  const invokers = Object.keys(props?.main! || {}).reduce(
+    (acc, currentChannel) => {
+      const ipcChannel = currentChannel as MainKeys
 
-    return {
-      ...acc,
+      return {
+        ...acc,
 
-      [ipcChannel]: async (...args: any[]) => {
-        return ipcRenderer.invoke(ipcChannel, ...args)
-      },
-    }
-  }, {}) as {
+        [ipcChannel]: async (...args: any[]) => {
+          return ipcRenderer.invoke(ipcChannel, ...args)
+        },
+      }
+    },
+    {}
+  ) as {
     [Property in MainKeys]: (
       arg: Parameters<Main[Property]>[1] extends undefined
         ? void

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/normalize-path@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-path/-/normalize-path-3.0.0.tgz#bb5c46cab77b93350b4cf8d7ff1153f47189ae31"
+  integrity sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
As the main or renderer handlers declarations are optional, this pr fixes the undefined state when one of them are not provided!

Closes #19 