### PR TITLE
chore: docs and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@
 - 🕸️ All edges connected (APIs to handle all processes)
 - 💖 `invoke` and `handle` methods in both processes with the same expected behavior
 
+# Requirements
+- Node.js >= 14.0.0
+- Electron >= 12.0.0
+- TypeScript >= 4.8.0
+
 # 💬 Installation
 In your terminal, run:
 ```bash
@@ -83,6 +88,8 @@ export const { ipcMain, ipcRenderer, exposeApiToGlobalWindow } =
 ```
 
 On the **main process**:
+
+> :warning: Don't forget to add `sandbox: false` to the BrowserWindow because it's required to load the preload script properly!
 
 ```ts
 import { BrowserWindow, app } from 'electron'

--- a/apps/web/docs/getting-started/create-a-interprocess.mdx
+++ b/apps/web/docs/getting-started/create-a-interprocess.mdx
@@ -1,6 +1,6 @@
 ---
 title: Create a interprocess
-order: 3
+order: 4
 ---
 
 # Create a interprocess
@@ -51,6 +51,10 @@ export const { ipcMain, ipcRenderer, exposeApiToGlobalWindow } =
 <br />
 
 On the **main process**:
+
+<br />
+
+> ⚠️ Don't forget to add `sandbox: false` to the BrowserWindow because it's required to load the preload script properly!
 
 <br />
 

--- a/apps/web/docs/getting-started/installation.mdx
+++ b/apps/web/docs/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-order: 2
+order: 3
 ---
 
 # Installation

--- a/apps/web/docs/getting-started/requirements.mdx
+++ b/apps/web/docs/getting-started/requirements.mdx
@@ -1,0 +1,10 @@
+---
+title: Requirements
+order: 2
+---
+
+# Requirements
+
+- Node.js >= 14.0.0
+- Electron >= 12.0.0
+- TypeScript >= 4.8.0

--- a/packages/interprocess/package.json
+++ b/packages/interprocess/package.json
@@ -44,7 +44,7 @@
     "electron": "latest"
   },
   "peerDependencies": {
-    "electron": ">=8.0"
+    "electron": ">=12.0"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
- Update the docs to enforce the usage of `sandbox: false`
- Update requirements to use interprocess to:
    - Node.js >= 14.0.0
    - Electron >= 12.0.0
    - TypeScript >= 4.8.0